### PR TITLE
requirements.txt really modified

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ greenlet==3.1.1
 gunicorn==23.0.0
 itsdangerous==2.2.0
 Jinja2==3.1.4
-jwt==1.3.1
 Mako==1.3.5
 MarkupSafe==2.1.5
 packaging==24.1


### PR DESCRIPTION
File requirements.txt has been modified to exclude jwt from installing at the environment with "pipenv install" as Jwt is no longer compatible with  PyJWT.